### PR TITLE
[codex] Add Codex project harness

### DIFF
--- a/.agents/skills/astro-homepage-maintainer/SKILL.md
+++ b/.agents/skills/astro-homepage-maintainer/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: astro-homepage-maintainer
+description: Maintain and extend this Astro personal homepage. Use when working on Astro routes, layouts, components, Svelte islands, Tailwind CSS, content collection plumbing, tests, build behavior, dependencies, or project verification for this repository.
+---
+
+# Astro Homepage Maintainer
+
+## Workflow
+
+1. Read `AGENTS.md` and `references/project-map.md` before planning changes.
+2. Inspect the existing Astro route, component, content, and test pattern nearest to the request.
+3. Keep edits scoped to source files. Do not patch `dist/`, `.astro/`, `node_modules/`, `playwright-report/`, or `test-results/`.
+4. Prefer existing helpers in `src/lib/content.ts`, constants in `src/site.config.ts`, and collection schemas in `src/content.config.ts`.
+5. Preserve Japanese copy tone unless the edited page already uses another language.
+6. Add or update tests when behavior, schema, sorting, filtering, routing, or visible layout expectations change.
+7. Verify with the narrowest useful command, then use `pnpm build` when routes, content schemas, or rendered pages changed.
+
+## Command Selection
+
+- Source formatting or lint risk: run `pnpm check:code`.
+- Content helper or schema behavior: run `pnpm test`.
+- Astro route, layout, integration, or content collection changes: run `pnpm build`.
+- Navigation, responsive layout, or cross-page rendering changes: run `pnpm test:e2e`.
+- Codex harness changes: run `pnpm verify:codex`.
+
+## References
+
+- Read `references/project-map.md` for the repository map, ownership boundaries, and verification matrix.

--- a/.agents/skills/astro-homepage-maintainer/agents/openai.yaml
+++ b/.agents/skills/astro-homepage-maintainer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Astro Homepage Maintainer"
+  short_description: "Maintain this Astro personal site safely"
+  default_prompt: "Use $astro-homepage-maintainer to implement and verify a homepage change."

--- a/.agents/skills/astro-homepage-maintainer/references/project-map.md
+++ b/.agents/skills/astro-homepage-maintainer/references/project-map.md
@@ -1,0 +1,40 @@
+# Project Map
+
+## Stack
+
+- Astro 7 project with typed content collections in `src/content.config.ts`.
+- Svelte 5 is available for islands, but current core pages are Astro-first.
+- Tailwind CSS v4 is wired through `@tailwindcss/vite` in `astro.config.mjs`.
+- Biome owns linting and formatting.
+- Vitest owns unit tests in `tests/*.test.ts`.
+- Playwright owns browser tests in `tests/*.spec.ts`.
+
+## Source Boundaries
+
+- `src/pages/`: routes and page composition.
+- `src/layouts/BaseLayout.astro`: shared document shell and navigation.
+- `src/components/`: reusable Astro components.
+- `src/styles/global.css`: global Tailwind and site styles.
+- `src/lib/content.ts`: content helper functions such as filtering, sorting, and date formatting.
+- `src/site.config.ts`: site-level metadata and navigation data.
+- `src/content/**`: Markdown and MDX entries for blog, projects, notes, and books.
+- `public/`: static assets served as-is.
+
+## Generated Or External Directories
+
+Do not edit these as source:
+
+- `dist/`
+- `.astro/`
+- `node_modules/`
+- `playwright-report/`
+- `test-results/`
+
+## Verification Matrix
+
+- Type or Astro integration changes: `pnpm check`.
+- Formatting or lint changes: `pnpm check:code`.
+- Helper logic changes: `pnpm test`.
+- Route, layout, collection, or build pipeline changes: `pnpm build`.
+- Navigation or viewport behavior changes: `pnpm test:e2e`.
+- Codex harness changes under `AGENTS.md`, `.codex/**`, or `.agents/**`: `pnpm verify:codex`.

--- a/.agents/skills/homepage-content-author/SKILL.md
+++ b/.agents/skills/homepage-content-author/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: homepage-content-author
+description: Add, revise, or validate Markdown and MDX content for this Astro homepage. Use for blog posts, project entries, study notes, book notes, frontmatter, draft handling, collection schema updates, slugs, tags, and Japanese reader-facing content edits.
+---
+
+# Homepage Content Author
+
+## Workflow
+
+1. Read `references/content-schema.md` before adding or changing content.
+2. Choose the collection that matches the user's intent: blog, projects, notes, or books.
+3. Inspect nearby entries for filename, frontmatter, excerpt length, heading, and tone conventions.
+4. Use Markdown or MDX only when the requested content needs MDX features.
+5. Keep slugs stable and lowercase. Prefer descriptive hyphenated filenames.
+6. Use `draft: true` for unfinished work.
+7. Run `pnpm build` after content or schema changes. Run `pnpm test` when helper behavior changes.
+
+## Content Quality
+
+- Write concise descriptions because they appear in lists, RSS, and metadata.
+- Keep Japanese copy natural and direct.
+- Avoid inventing external facts, publication dates, URLs, repositories, or book metadata. Ask or leave draft placeholders when required facts are missing.
+- Update `src/content.config.ts` first when a new durable frontmatter field is needed.
+
+## References
+
+- Read `references/content-schema.md` for collection paths, required fields, optional fields, and examples.

--- a/.agents/skills/homepage-content-author/agents/openai.yaml
+++ b/.agents/skills/homepage-content-author/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Homepage Content Author"
+  short_description: "Add typed Markdown and MDX content"
+  default_prompt: "Use $homepage-content-author to add or revise content in this homepage."

--- a/.agents/skills/homepage-content-author/references/content-schema.md
+++ b/.agents/skills/homepage-content-author/references/content-schema.md
@@ -1,0 +1,74 @@
+# Content Schema
+
+## Common Fields
+
+Every collection entry requires:
+
+```yaml
+title: "Entry title"
+description: "Short summary for lists and metadata."
+pubDate: 2026-06-27
+```
+
+Optional common fields:
+
+```yaml
+updatedDate: 2026-06-28
+draft: true
+tags:
+  - astro
+  - note
+```
+
+## Collections
+
+### Blog
+
+- Path: `src/content/blog`
+- Pattern: `**/*.{md,mdx}`
+- Use for essays, updates, and longer posts.
+- Schema: common fields only.
+
+### Projects
+
+- Path: `src/content/projects`
+- Pattern: `**/*.{md,mdx}`
+- Use for things the site owner made.
+- Extra optional fields:
+
+```yaml
+url: "https://example.com"
+repository: "https://github.com/user/repo"
+featured: true
+```
+
+### Notes
+
+- Path: `src/content/notes`
+- Pattern: `**/*.{md,mdx}`
+- Use for study notes and technical notes.
+- Extra optional field:
+
+```yaml
+topic: "Astro"
+```
+
+### Books
+
+- Path: `src/content/books`
+- Pattern: `**/*.{md,mdx}`
+- Use for reading notes.
+- Extra fields:
+
+```yaml
+bookTitle: "Book title"
+bookAuthor: "Author name"
+status: "reading"
+```
+
+`status` must be one of `reading`, `finished`, or `paused`.
+
+## Validation
+
+- Run `pnpm build` after adding or editing entries.
+- Run `pnpm test` when changing content helper behavior in `src/lib/content.ts`.

--- a/.codex/agents/homepage-explorer.toml
+++ b/.codex/agents/homepage-explorer.toml
@@ -1,0 +1,12 @@
+name = "homepage-explorer"
+description = "Read-only explorer for this Astro homepage. Use for codebase mapping, dependency impact checks, and content/schema discovery before implementation."
+sandbox_mode = "read-only"
+model_reasoning_effort = "low"
+nickname_candidates = ["Explorer Alpha", "Explorer Beta", "Explorer Gamma"]
+developer_instructions = """
+Explore the repository without editing files.
+Focus on Astro routes, content collections, components, tests, and existing conventions.
+Return concise findings with file references and avoid dumping raw command output.
+Prefer `rg`, `rg --files`, and targeted file reads.
+When asked for implementation advice, identify the smallest source files that need changes and the verification commands that would prove the change.
+"""

--- a/.codex/agents/homepage-reviewer.toml
+++ b/.codex/agents/homepage-reviewer.toml
@@ -1,0 +1,12 @@
+name = "homepage-reviewer"
+description = "Review agent for correctness, accessibility, content schema, routing, security, dependency, and missing-test risks in this homepage."
+sandbox_mode = "read-only"
+model_reasoning_effort = "high"
+nickname_candidates = ["Reviewer One", "Reviewer Two", "Reviewer Three"]
+developer_instructions = """
+Review like a repository owner.
+Lead with concrete findings ordered by severity and include file references.
+Prioritize broken routes, invalid Astro content collections, accessibility regressions, layout regressions, unsafe shell or dependency guidance, and missing tests.
+Do not summarize style preferences as findings unless they create a real maintainability or user-facing risk.
+Call out verification gaps when a change affects rendering, routing, or content schema but lacks `pnpm build`, `pnpm test`, or Playwright coverage.
+"""

--- a/.codex/agents/homepage-verifier.toml
+++ b/.codex/agents/homepage-verifier.toml
@@ -1,0 +1,12 @@
+name = "homepage-verifier"
+description = "Verification agent for running and interpreting checks for this Astro homepage, including Biome, Vitest, Astro build, Playwright, and Codex harness validation."
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "medium"
+nickname_candidates = ["Verifier One", "Verifier Two", "Verifier Three"]
+developer_instructions = """
+Run verification commands and report the result clearly.
+Prefer the narrowest command that proves the requested change, then broaden when user-facing rendering, routes, content schemas, or harness files changed.
+Use `pnpm check:code`, `pnpm test`, `pnpm build`, `pnpm test:e2e`, and `pnpm verify:codex` as appropriate.
+Do not edit source files unless the parent task explicitly asks you to fix failures.
+When a command fails, return the failing command, exit status, key error lines, and the likely owning file.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,20 @@
+# Project-scoped Codex configuration for this repository.
+
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+project_doc_max_bytes = 65536
+project_doc_fallback_filenames = ["README.md"]
+
+[features]
+hooks = true
+
+[agents]
+max_threads = 6
+max_depth = 1
+job_max_runtime_seconds = 1800
+
+[sandbox_workspace_write]
+writable_roots = []
+network_access = false
+exclude_tmpdir_env_var = false
+exclude_slash_tmp = false

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,41 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(Bash|exec_command|functions\\.exec_command)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/project_guard.py\" pre-tool",
+            "timeout": 10,
+            "statusMessage": "Checking project command policy"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/project_guard.py\" user-prompt",
+            "timeout": 10,
+            "statusMessage": "Checking prompt for accidental secrets"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/project_guard.py\" stop",
+            "timeout": 10,
+            "statusMessage": "Checking project verification reminders"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/project_guard.py
+++ b/.codex/hooks/project_guard.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Repo-local Codex hook handlers for the homepage project."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+
+BLOCKED_COMMANDS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"\bgit\s+reset\s+--hard\b"),
+        "Do not run `git reset --hard` from an agent session. Preserve user work.",
+    ),
+    (
+        re.compile(r"\bgit\s+clean\s+-[^\n]*[fdx][^\n]*\b"),
+        "Do not run destructive `git clean` commands from an agent session.",
+    ),
+    (
+        re.compile(r"\brm\s+-[^\n]*[rf][^\n]*\s+(?:/|~|\$HOME|\.\.?|\S*/\.git)(?:\s|$)"),
+        "The command looks like a broad destructive removal. Narrow the path or ask explicitly.",
+    ),
+    (
+        re.compile(r"\b(?:npm|yarn|bun)\s+(?:install|add|remove|update)\b"),
+        "This repository uses pnpm. Use the matching `pnpm` command instead.",
+    ),
+    (
+        re.compile(r"\b(?:curl|wget)\b[^\n|]*(?:\|\s*(?:sh|bash|zsh)|>\s*/tmp/)", re.IGNORECASE),
+        "Do not pipe downloaded scripts into a shell from a project agent workflow.",
+    ),
+    (
+        re.compile(r"\bchmod\s+-R\s+777\b"),
+        "Do not recursively make project files world-writable.",
+    ),
+)
+
+SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"), "OpenAI-style API key"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "AWS access key id"),
+    (re.compile(r"(?i)\b(?:api|access|secret|refresh)_?token\s*=\s*['\"]?[\w./+=-]{16,}"), "token assignment"),
+    (re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"), "private key"),
+)
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    event = read_event()
+
+    if mode == "pre-tool":
+        return pre_tool(event)
+    if mode == "user-prompt":
+        return user_prompt(event)
+    if mode == "stop":
+        return stop(event)
+
+    print(f"Unknown hook mode: {mode}", file=sys.stderr)
+    return 1
+
+
+def read_event() -> Any:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"raw": raw}
+
+
+def pre_tool(event: Any) -> int:
+    command = extract_command(event)
+    if not command:
+        return 0
+
+    for pattern, message in BLOCKED_COMMANDS:
+        if pattern.search(command):
+            print(f"Blocked by homepage Codex hook: {message}", file=sys.stderr)
+            print(f"Command: {command}", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+def user_prompt(event: Any) -> int:
+    text = extract_prompt_text(event)
+    if not text:
+        return 0
+
+    findings = [label for pattern, label in SECRET_PATTERNS if pattern.search(text)]
+    if findings:
+        joined = ", ".join(findings)
+        print(f"Blocked by homepage Codex hook: possible secret in prompt ({joined}).", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def stop(event: Any) -> int:
+    repo_root = find_repo_root()
+    if repo_root is None:
+        return 0
+
+    changed = changed_files(repo_root)
+    if not changed:
+        return 0
+
+    touched = "\n".join(f"  - {path}" for path in changed[:20])
+    print("Homepage Codex reminder: verify changed source before finalizing.", file=sys.stderr)
+    print(touched, file=sys.stderr)
+
+    if any(path.startswith((".codex/", ".agents/")) or path == "AGENTS.md" for path in changed):
+        print("Run `pnpm verify:codex` for harness changes.", file=sys.stderr)
+    if any(path.startswith(("src/", "tests/")) or path in PROJECT_CODE_FILES for path in changed):
+        print("Run the relevant checks, usually `pnpm check:code`, `pnpm test`, and `pnpm build`.", file=sys.stderr)
+
+    return 0
+
+
+def extract_command(value: Any) -> str:
+    for found in walk_strings_for_keys(value, {"command", "cmd", "shell_command"}):
+        if found.strip():
+            return found.strip()
+    return ""
+
+
+def extract_prompt_text(value: Any) -> str:
+    direct = list(walk_strings_for_keys(value, {"prompt", "user_prompt", "text", "content", "raw"}))
+    if direct:
+        return "\n".join(direct)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def walk_strings_for_keys(value: Any, keys: set[str]) -> Iterable[str]:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in keys and isinstance(item, str):
+                yield item
+            else:
+                yield from walk_strings_for_keys(item, keys)
+    elif isinstance(value, list):
+        for item in value:
+            yield from walk_strings_for_keys(item, keys)
+
+
+def find_repo_root() -> Path | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return Path(result.stdout.strip())
+
+
+def changed_files(repo_root: Path) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [path for line in result.stdout.splitlines() if (path := parse_status_path(line))]
+
+
+def parse_status_path(line: str) -> str:
+    if len(line) < 4:
+        return ""
+
+    path = line[3:]
+    if " -> " in path:
+        path = path.rsplit(" -> ", 1)[1]
+    return path.strip('"')
+
+
+PROJECT_CODE_FILES = {
+    "astro.config.mjs",
+    "biome.json",
+    "package.json",
+    "playwright.config.ts",
+    "src/content.config.ts",
+    "src/site.config.ts",
+    "tsconfig.json",
+    "vitest.config.ts",
+}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/verify_harness.py
+++ b/.codex/verify_harness.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Validate this repository's Codex harness files."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / ".codex" / "config.toml"
+HOOKS = ROOT / ".codex" / "hooks.json"
+HOOK_SCRIPT = ROOT / ".codex" / "hooks" / "project_guard.py"
+AGENTS_DIR = ROOT / ".codex" / "agents"
+SKILLS_DIR = ROOT / ".agents" / "skills"
+
+
+def main() -> int:
+    checks = [
+        check_agents_md,
+        check_config,
+        check_hooks,
+        check_custom_agents,
+        check_skills,
+        check_hook_behavior,
+    ]
+    for check in checks:
+        check()
+    print("Codex harness verification passed.")
+    return 0
+
+
+def check_agents_md() -> None:
+    content = read(ROOT / "AGENTS.md")
+    require("pnpm verify:codex" in content, "AGENTS.md must document harness verification.")
+    require(".agents/skills" in content, "AGENTS.md must mention repo-scoped skills.")
+    require(".codex/agents" in content, "AGENTS.md must mention custom subagents.")
+
+
+def check_config() -> None:
+    data = load_toml(CONFIG)
+    require(data.get("sandbox_mode") == "workspace-write", ".codex/config.toml must use workspace-write.")
+    require(data.get("approval_policy") == "on-request", ".codex/config.toml must use on-request approvals.")
+    require(data.get("features", {}).get("hooks") is True, ".codex/config.toml must enable hooks.")
+    agents = data.get("agents", {})
+    require(agents.get("max_depth") == 1, ".codex/config.toml must keep subagent depth at 1.")
+    require(agents.get("max_threads", 0) >= 3, ".codex/config.toml must allow parallel subagents.")
+
+
+def check_hooks() -> None:
+    data = json.loads(read(HOOKS))
+    hooks = data.get("hooks", {})
+    for event in ("PreToolUse", "UserPromptSubmit", "Stop"):
+        require(event in hooks, f"{HOOKS} must define {event}.")
+    pre_tool_matchers = [group.get("matcher", "") for group in hooks.get("PreToolUse", [])]
+    joined_matchers = "\n".join(pre_tool_matchers)
+    require("Bash" in joined_matchers, f"{HOOKS} PreToolUse matcher must cover Bash.")
+    require("exec_command" in joined_matchers, f"{HOOKS} PreToolUse matcher must cover Codex exec_command.")
+    for command in hook_commands(data):
+        require("$(git rev-parse --show-toplevel)" in command, "Hook commands must resolve from git root.")
+        require(".codex/hooks/project_guard.py" in command, "Hook commands must call project_guard.py.")
+    require(HOOK_SCRIPT.exists(), "project_guard.py is missing.")
+
+
+def check_custom_agents() -> None:
+    expected = {"homepage-explorer.toml", "homepage-reviewer.toml", "homepage-verifier.toml"}
+    actual = {path.name for path in AGENTS_DIR.glob("*.toml")}
+    require(expected <= actual, f"Missing custom agent files: {sorted(expected - actual)}")
+    for path in AGENTS_DIR.glob("*.toml"):
+        data = load_toml(path)
+        for key in ("name", "description", "developer_instructions"):
+            require(data.get(key), f"{path} must define {key}.")
+        require("homepage" in data["name"], f"{path} name should be project scoped.")
+
+
+def check_skills() -> None:
+    expected = {"astro-homepage-maintainer", "homepage-content-author"}
+    actual = {path.name for path in SKILLS_DIR.iterdir() if path.is_dir()}
+    require(expected <= actual, f"Missing skill folders: {sorted(expected - actual)}")
+    for skill_dir in sorted(SKILLS_DIR.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_md = skill_dir / "SKILL.md"
+        content = read(skill_md)
+        require("TODO" not in content, f"{skill_md} still contains TODO text.")
+        frontmatter = parse_frontmatter(content)
+        require(frontmatter.get("name") == skill_dir.name, f"{skill_md} name must match folder.")
+        require(frontmatter.get("description"), f"{skill_md} must define description.")
+        require((skill_dir / "agents" / "openai.yaml").exists(), f"{skill_dir} missing agents/openai.yaml.")
+
+
+def check_hook_behavior() -> None:
+    allowed = run_hook("pre-tool", {"tool_input": {"command": "pnpm test"}})
+    require(allowed.returncode == 0, "pre-tool hook must allow pnpm test.")
+
+    blocked = run_hook("pre-tool", {"tool_input": {"command": "npm install left-pad"}})
+    require(blocked.returncode != 0, "pre-tool hook must block npm install.")
+
+    secret = run_hook("user-prompt", {"prompt": "OPENAI_API_TOKEN=sk-abcdefghijklmnopqrstuvwxyz123456"})
+    require(secret.returncode != 0, "user-prompt hook must block high-confidence secrets.")
+
+    with tempfile.TemporaryDirectory(prefix="homepage-codex-harness-") as workspace:
+        temp_repo = Path(workspace)
+        subprocess.run(["git", "init"], cwd=temp_repo, capture_output=True, text=True, check=True)
+        sentinel = temp_repo / ".codex" / "untracked-harness-file"
+        sentinel.parent.mkdir()
+        sentinel.write_text("temporary harness verification sentinel\n", encoding="utf-8")
+
+        untracked = run_hook("stop", {}, cwd=temp_repo)
+        output = f"{untracked.stdout}\n{untracked.stderr}"
+        require(untracked.returncode == 0, "stop hook must not fail with untracked harness files.")
+        require("pnpm verify:codex" in output, "stop hook must notice untracked harness files.")
+
+    stop = run_hook("stop", {})
+    require(stop.returncode == 0, "stop hook must not fail normal runs.")
+
+
+def run_hook(mode: str, payload: object, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/usr/bin/python3", str(HOOK_SCRIPT), mode],
+        input=json.dumps(payload),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def hook_commands(data: object) -> list[str]:
+    commands: list[str] = []
+    if not isinstance(data, dict):
+        return commands
+    for groups in data.get("hooks", {}).values():
+        for group in groups:
+            for hook in group.get("hooks", []):
+                command = hook.get("command")
+                if command:
+                    commands.append(command)
+    return commands
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as file:
+        return tomllib.load(file)
+
+
+def read(path: Path) -> str:
+    require(path.exists(), f"Missing file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def parse_frontmatter(content: str) -> dict[str, str]:
+    match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+    require(match is not None, "Skill is missing YAML frontmatter.")
+    values: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        key, _, value = line.partition(":")
+        values[key.strip()] = value.strip().strip('"')
+    return values
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"Codex harness verification failed: {message}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Project Profile
+
+- This is a personal homepage built with Astro 7, Svelte 5 islands, Tailwind CSS v4, and typed Markdown / MDX content collections.
+- Use `pnpm` for every package and script command. Do not introduce npm, yarn, bun, or a second lockfile.
+- Keep user-facing copy suitable for Japanese readers unless the edited page already uses another language.
+- Treat generated directories as disposable output: `dist/`, `.astro/`, `playwright-report/`, `test-results/`, and `node_modules/` are not source.
+
+## Workflows
+
+- Install dependencies with `pnpm install`.
+- Start local development with `pnpm dev`.
+- Run static and type checks with `pnpm check`.
+- Run formatter and linter checks with `pnpm check:code`.
+- Run unit tests with `pnpm test`.
+- Run production build with `pnpm build`.
+- Run E2E tests with `pnpm test:e2e` when navigation, layout, routing, or rendered pages change.
+- Run Codex harness verification with `pnpm verify:codex` after changing `AGENTS.md`, `.codex/**`, or `.agents/**`.
+
+## Coding Rules
+
+- Prefer existing Astro component and content collection patterns over new abstractions.
+- Keep content helpers in `src/lib/content.ts`; keep site-wide constants in `src/site.config.ts`.
+- Update `src/content.config.ts` before adding new frontmatter fields, then add tests that prove the schema or helper behavior.
+- Preserve Biome formatting: 2 spaces, single quotes in JavaScript and TypeScript, trailing commas where Biome applies them.
+- Do not edit generated files to fix source behavior.
+- Avoid adding production dependencies unless the requested feature clearly requires them.
+
+## Content Rules
+
+- Blog posts live in `src/content/blog`.
+- Project entries live in `src/content/projects`.
+- Study notes live in `src/content/notes`.
+- Book notes live in `src/content/books`.
+- Required frontmatter for every collection entry: `title`, `description`, and `pubDate`.
+- Use ISO-like dates in frontmatter, for example `2026-06-27`.
+- Set `draft: true` for unfinished entries instead of hiding them by filename.
+
+## Codex Harness
+
+- Project-scoped Codex config lives in `.codex/config.toml`.
+- Lifecycle hooks live in `.codex/hooks.json` and `.codex/hooks/`.
+- Custom subagents live in `.codex/agents/*.toml`.
+- Repo-scoped skills live in `.agents/skills/*/SKILL.md`.
+- Use `$astro-homepage-maintainer` for implementation, refactors, styling, routing, and verification work.
+- Use `$homepage-content-author` for adding or revising Markdown / MDX collection entries.
+
+## Review Guidelines
+
+- Prioritize correctness, broken routes, invalid content schemas, missing tests, accessibility regressions, and layout regressions.
+- Treat accidental secret exposure, unsafe shell guidance, or dependency-manager drift as high-priority findings.
+- Verify changes with the narrowest command that proves the behavior, then broaden to `pnpm build` or `pnpm test:e2e` when the change affects rendering or routing.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check:code": "biome check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "pnpm build && playwright test"
+    "test:e2e": "pnpm build && playwright test",
+    "verify:codex": "python3 .codex/verify_harness.py"
   },
   "dependencies": {
     "@astrojs/mdx": "7.0.0",


### PR DESCRIPTION
## Summary

- Add project-scoped Codex guidance in `AGENTS.md`.
- Add Codex config, lifecycle hooks, custom agents, repo-scoped skills, and harness verification.
- Add `pnpm verify:codex` so harness changes can be validated from the standard project workflow.

## Impact

This gives future Codex sessions clearer repository rules, safer command/prompt checks, and focused homepage maintenance/content authoring workflows.

## Validation

- `pnpm verify:codex`